### PR TITLE
Running the docker container using port binding

### DIFF
--- a/build-jenkins-image.sh
+++ b/build-jenkins-image.sh
@@ -1,4 +1,4 @@
 
 cd docker/
 
-docker build --network=host -t edu.cscc.special-topics/jenkins .
+docker build -p 8080:8080 -t edu.cscc.special-topics/jenkins .

--- a/run-jenkins.sh
+++ b/run-jenkins.sh
@@ -4,4 +4,4 @@ echo "making $REPO_DIR readable for local development"
 chmod a+x ${REPO_DIR}
 chmod -R a+r ${REPO_DIR}
 chmod -R a+x ${REPO_DIR}/.git
-docker run --net=host --volume ${REPO_DIR}:${REPO_DIR} --name jenkins --rm edu.cscc.special-topics/jenkins:latest
+docker run -p 8080:8080 --volume ${REPO_DIR}:${REPO_DIR} --name jenkins --rm edu.cscc.special-topics/jenkins:latest


### PR DESCRIPTION
## Context 
This PR updates the scripts to build and run Jenkins using port binding instead of the `--network=host` to insure more flexible configuration operations. This method makes it more visible which ports are necessary for Jenkins to run.